### PR TITLE
Follow-up: address review feedback across issues #1-#9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - "v*"
   workflow_dispatch:
     inputs:
+      tag_name:
+        description: "Release tag name (for example v0.1.0-rc1)"
+        required: true
+        type: string
       prerelease:
         description: "Publish as prerelease"
         required: false
@@ -52,6 +56,7 @@ jobs:
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
           files: dist/*
           generate_release_notes: true
           prerelease: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# AGENTS.md
+
+Guidance for coding agents working in `rec`.
+
+## Project intent
+
+- `rec` is a local-first long-form audio transcription and summarization pipeline.
+- Baseline operation must work without external API keys.
+- External providers are optional and opt-in only.
+
+## Core architecture and contracts
+
+- CLI entrypoint: `rec` (`src/rec_pipeline/cli.py`).
+- Ordered pipeline stages:
+  1. Ingestion/normalization
+  2. ASR
+  3. Optional diarization
+  4. Transcript assembly/writers
+  5. Summarization
+  6. Optional evaluation (`rec evaluate`)
+- Run outputs are run-scoped under `artifacts/<run-name>/`.
+- Stage outputs are treated as contracts for downstream stages. Preserve compatibility when changing payloads.
+
+## Resumability and determinism
+
+- Long runs are resume-safe via checkpoint files in `checkpoints/`.
+- Stage reruns should skip completed artifacts when checkpoint + output exist.
+- File ordering and generated naming must remain deterministic.
+- Avoid introducing nondeterministic output ordering.
+
+## Local-first and providers
+
+- Keep `local` as default for ASR and summary providers.
+- External provider selection is explicit (`openai`, `deepgram`, `groq`).
+- Missing required keys for selected providers must fail fast with actionable messages.
+- Preserve `REC_EXTERNAL_FALLBACK_TO_LOCAL` behavior.
+- Never log raw secrets; redact keys/tokens in errors and logs.
+
+## Transcript and summary quality expectations
+
+- ASR segment timestamps must be monotonic and valid (`start < end`).
+- Transcript artifacts must remain valid/deterministic:
+  - `transcript.txt`
+  - `transcript.srt`
+  - `transcript.json`
+- Summary outputs must include these sections:
+  - overview
+  - key points
+  - decisions
+  - action items
+  - open questions
+- Keep timestamp citations for major summary sections when source timing exists.
+
+## Diarization behavior
+
+- Diarization is optional and should degrade gracefully.
+- If diarization fails and fail-fast is disabled, continue with `UNKNOWN` speaker labels.
+- Preserve speaker-aware outputs and optional per-speaker exports.
+- If diarization is enabled, document/token requirements must remain explicit.
+
+## Evaluation and gates
+
+- Evaluation command: `rec evaluate`.
+- Maintain metrics and report schema:
+  - WER/CER
+  - DER proxy
+  - summary traceability coverage
+- Preserve warning-first gate mode and blocking-gates option.
+- Keep at least one long multi-file scenario in evaluation datasets.
+
+## Engineering workflow
+
+- Python 3.11+.
+- Preferred checks before submitting changes:
+  - `make lint`
+  - `make format-check`
+  - `make typecheck`
+  - `make test`
+- Keep mypy strictness intact unless there is a strong reason to relax it.
+- Add or update tests for behavioral changes.
+
+## CI/CD and release guardrails
+
+- Keep workflows healthy:
+  - `.github/workflows/ci.yml`
+  - `.github/workflows/nightly-evaluation.yml`
+  - `.github/workflows/release.yml`
+- Do not bypass branch protection expectations for `main`.
+- Preserve required checks used by branch protection.
+
+## PR and branching best practices
+
+- Use focused branches and small diffs.
+- If using stacked work, set PR base to the previous branch intentionally.
+- Document validation steps in PR descriptions.
+- Include migration/compatibility notes when changing artifact schemas.
+
+## Common pitfalls
+
+- Breaking downstream stage by changing JSON payload keys silently.
+- Removing checkpoint semantics and causing full reprocessing.
+- Making external providers effectively required.
+- Emitting logs that include raw API keys/tokens.
+
+## Definition of done for changes
+
+- Behavior is implemented and documented.
+- Backward compatibility is addressed or explicitly documented.
+- Local quality gates pass.
+- Relevant CI/evaluation paths are considered.

--- a/docs/ci-validation.md
+++ b/docs/ci-validation.md
@@ -8,10 +8,12 @@
 
 ## Release workflow validation
 
-1. Trigger `Release` workflow via `workflow_dispatch` with `prerelease=true`.
+1. Trigger `Release` workflow via `workflow_dispatch` with:
+   - `tag_name` set to a temporary prerelease tag (for example `v0.0.0-rc1`)
+   - `prerelease=true`
 2. Confirm wheel/sdist artifacts are produced and attached to the prerelease.
-3. Trigger release by pushing a temporary test tag (for example `v0.0.0-rc1`) if needed.
-4. Remove test tag/release after validation.
+3. Optionally validate tag-push release flow by pushing the same temporary test tag.
+4. Remove temporary tag/release after validation.
 
 ## Secrets policy
 

--- a/src/rec_pipeline/cli.py
+++ b/src/rec_pipeline/cli.py
@@ -246,7 +246,9 @@ def _handle_run(args: argparse.Namespace) -> int:
     vad_filter = (
         settings.asr_vad_filter if args.asr_vad_filter is None else bool(args.asr_vad_filter)
     )
-    asr_max_retries = args.asr_max_retries or settings.asr_max_retries
+    asr_max_retries = (
+        args.asr_max_retries if args.asr_max_retries is not None else settings.asr_max_retries
+    )
 
     asr_transcriber: Transcriber
     if requested_asr_provider == "local":
@@ -358,7 +360,11 @@ def _handle_run(args: argparse.Namespace) -> int:
         print("Diarization summary: disabled")
     transcript_builder = TranscriptArtifactBuilder()
     try:
-        transcript_result = transcript_builder.build(run_dir=run_dir, language=language)
+        transcript_result = transcript_builder.build(
+            run_dir=run_dir,
+            language=language,
+            prefer_diarized=diarization_enabled,
+        )
     except TranscriptError as exc:
         print(f"Transcript assembly failed: {exc}")
         return 1

--- a/src/rec_pipeline/config.py
+++ b/src/rec_pipeline/config.py
@@ -82,7 +82,7 @@ def load_settings(env_file: str | Path | None = None) -> RecSettings:
     if env_file is not None:
         load_dotenv(dotenv_path=Path(env_file), override=False)
     else:
-        load_dotenv(override=False)
+        load_dotenv(dotenv_path=Path.cwd() / ".env", override=False)
 
     return RecSettings(
         asr_provider=os.getenv("REC_ASR_PROVIDER", "local"),

--- a/src/rec_pipeline/summary.py
+++ b/src/rec_pipeline/summary.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import urllib.error
@@ -250,17 +251,16 @@ def synthesize_global_summary(
     chunk_summaries: list[ChunkSummary], *, language: str
 ) -> SummaryDocument:
     if not chunk_summaries:
-        empty_item = SummaryItem(
-            text="Sem dados suficientes." if language.startswith("pt") else "No data.", citations=[]
-        )
+        no_data = "Sem dados suficientes." if language.startswith("pt") else "No data."
+        empty_item = SummaryItem(text=no_data, citations=[])
         return SummaryDocument(
             language=language,
             chunk_summaries=[],
             overview=empty_item,
-            key_points=[],
-            decisions=[],
-            action_items=[],
-            open_questions=[],
+            key_points=[SummaryItem(text=no_data, citations=[])],
+            decisions=[SummaryItem(text=no_data, citations=[])],
+            action_items=[SummaryItem(text=no_data, citations=[])],
+            open_questions=[SummaryItem(text=no_data, citations=[])],
         )
 
     citations = [item.citations[0] for item in chunk_summaries if item.citations]
@@ -467,6 +467,25 @@ class SummaryPipeline:
             ("summary.json", json_path, checkpoints_dir / "summary.json.done"),
         ]
 
+        transcript_hash = _file_sha256(run_dir / "artifacts" / "transcript.json")
+        all_outputs_checkpointed = all(
+            checkpoint_path.exists() and output_path.exists()
+            for _, output_path, checkpoint_path in jobs
+        )
+        if all_outputs_checkpointed and self._is_manifest_up_to_date(
+            manifest_path=manifest_path,
+            transcript_hash=transcript_hash,
+        ):
+            for label, _, _ in jobs:
+                self._log(log_path, "summary_skip_checkpoint", file=label)
+            return SummaryArtifactResult(
+                markdown_path=markdown_path,
+                json_path=json_path,
+                manifest_path=manifest_path,
+                generated_files=[],
+                skipped_files=[label for label, _, _ in jobs],
+            )
+
         segments = load_transcript_segments(run_dir)
         chunks = chunk_transcript(
             segments,
@@ -527,6 +546,7 @@ class SummaryPipeline:
             "model_backend": self._model_backend,
             "model_name": self._model_name,
             "chunk_count": len(chunks),
+            "input_transcript_sha256": transcript_hash,
             "generated_files": generated_files,
             "skipped_files": skipped_files,
             "artifacts": {
@@ -547,6 +567,16 @@ class SummaryPipeline:
             skipped_files=skipped_files,
         )
 
+    def _is_manifest_up_to_date(self, *, manifest_path: Path, transcript_hash: str) -> bool:
+        if not manifest_path.exists():
+            return False
+        try:
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return False
+        input_hash = payload.get("input_transcript_sha256")
+        return isinstance(input_hash, str) and input_hash == transcript_hash
+
     def _build_model(self) -> SummaryModel:
         backend = self._model_backend.lower()
         if backend == "ollama":
@@ -561,3 +591,12 @@ class SummaryPipeline:
         entry = {"event": event, "payload": payload}
         with log_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def _file_sha256(path: Path) -> str:
+    if not path.exists():
+        raise SummaryError(f"Missing transcript artifact: {path}")
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as exc:
+        raise SummaryError(f"Failed to read transcript artifact '{path}': {exc}") from exc

--- a/src/rec_pipeline/transcript.py
+++ b/src/rec_pipeline/transcript.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -67,13 +68,17 @@ def _parse_ingestion_offsets(run_dir: Path) -> dict[str, float]:
     return offsets
 
 
-def _load_asr_payload(run_dir: Path) -> dict[str, object]:
+def _load_asr_payload(run_dir: Path, *, prefer_diarized: bool | None) -> dict[str, object]:
     diarized_asr_path = run_dir / "asr" / "speaker_transcript_segments.json"
-    asr_payload_path = (
-        diarized_asr_path
-        if diarized_asr_path.exists()
-        else run_dir / "asr" / "raw_transcript_segments.json"
-    )
+    raw_asr_path = run_dir / "asr" / "raw_transcript_segments.json"
+    asr_payload_path = raw_asr_path
+    if _should_use_diarized_asr_payload(
+        run_dir=run_dir,
+        raw_asr_path=raw_asr_path,
+        diarized_asr_path=diarized_asr_path,
+        prefer_diarized=prefer_diarized,
+    ):
+        asr_payload_path = diarized_asr_path
     if not asr_payload_path.exists():
         raise TranscriptError(f"Missing ASR aggregate payload: {asr_payload_path}")
     payload = json.loads(asr_payload_path.read_text(encoding="utf-8"))
@@ -82,9 +87,43 @@ def _load_asr_payload(run_dir: Path) -> dict[str, object]:
     return payload
 
 
-def assemble_transcript(run_dir: Path, *, language: str) -> TranscriptDocument:
+def _should_use_diarized_asr_payload(
+    *,
+    run_dir: Path,
+    raw_asr_path: Path,
+    diarized_asr_path: Path,
+    prefer_diarized: bool | None,
+) -> bool:
+    if not diarized_asr_path.exists():
+        return False
+    if prefer_diarized is False:
+        return False
+    if raw_asr_path.exists() and diarized_asr_path.stat().st_mtime < raw_asr_path.stat().st_mtime:
+        return False
+    if prefer_diarized is True:
+        return True
+    return _read_diarization_enabled_from_run_metadata(run_dir)
+
+
+def _read_diarization_enabled_from_run_metadata(run_dir: Path) -> bool:
+    metadata_path = run_dir / "run_metadata.json"
+    if not metadata_path.exists():
+        return False
+    try:
+        payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return False
+    return bool(payload.get("diarization_enabled", False))
+
+
+def assemble_transcript(
+    run_dir: Path,
+    *,
+    language: str,
+    prefer_diarized: bool | None = None,
+) -> TranscriptDocument:
     offsets = _parse_ingestion_offsets(run_dir)
-    asr_payload = _load_asr_payload(run_dir)
+    asr_payload = _load_asr_payload(run_dir, prefer_diarized=prefer_diarized)
 
     files_payload = asr_payload.get("files", [])
     if not isinstance(files_payload, list):
@@ -148,13 +187,20 @@ def assemble_transcript(run_dir: Path, *, language: str) -> TranscriptDocument:
         key=lambda item: (item.absolute_start_sec, item.absolute_end_sec, item.segment_id)
     )
 
+    previous_start = -1.0
     previous_end = -1.0
     for segment in assembled:
-        if segment.absolute_start_sec < previous_end:
+        if segment.absolute_start_sec < previous_start:
             raise TranscriptError(
                 "Absolute timeline is non-monotonic after stitching "
-                f"at segment {segment.segment_id}: {segment.absolute_start_sec} < {previous_end}"
+                f"at segment {segment.segment_id}: {segment.absolute_start_sec} < {previous_start}"
             )
+        if segment.absolute_end_sec < previous_end:
+            raise TranscriptError(
+                "Absolute timeline has non-monotonic end timestamps "
+                f"at segment {segment.segment_id}: {segment.absolute_end_sec} < {previous_end}"
+            )
+        previous_start = segment.absolute_start_sec
         previous_end = segment.absolute_end_sec
 
     return TranscriptDocument(language=language, segments=assembled)
@@ -309,7 +355,13 @@ def _optional_str(value: object) -> str | None:
 
 
 class TranscriptArtifactBuilder:
-    def build(self, *, run_dir: Path, language: str) -> TranscriptArtifactResult:
+    def build(
+        self,
+        *,
+        run_dir: Path,
+        language: str,
+        prefer_diarized: bool | None = None,
+    ) -> TranscriptArtifactResult:
         artifacts_dir = run_dir / "artifacts"
         checkpoints_dir = run_dir / "checkpoints"
         logs_dir = run_dir / "logs"
@@ -318,7 +370,12 @@ class TranscriptArtifactBuilder:
         logs_dir.mkdir(parents=True, exist_ok=True)
         log_path = logs_dir / "transcript.jsonl"
 
-        document = assemble_transcript(run_dir, language=language)
+        document = assemble_transcript(
+            run_dir,
+            language=language,
+            prefer_diarized=prefer_diarized,
+        )
+        document_hash = _document_hash(document)
 
         transcript_path = artifacts_dir / "transcript.txt"
         srt_path = artifacts_dir / "transcript.srt"
@@ -348,9 +405,11 @@ class TranscriptArtifactBuilder:
 
         generated_files: list[str] = []
         skipped_files: list[str] = []
+        previous_manifest_hash = self._read_previous_manifest_hash(manifest_path)
+        force_rebuild = previous_manifest_hash != document_hash
 
         for label, output_path, checkpoint_path, writer in jobs:
-            if checkpoint_path.exists() and output_path.exists():
+            if not force_rebuild and checkpoint_path.exists() and output_path.exists():
                 skipped_files.append(label)
                 self._log(log_path, "transcript_skip_checkpoint", file=label)
                 continue
@@ -362,6 +421,7 @@ class TranscriptArtifactBuilder:
         manifest_payload = {
             "language": language,
             "segment_count": len(document.segments),
+            "document_hash": document_hash,
             "generated_files": generated_files,
             "skipped_files": skipped_files,
             "artifacts": {
@@ -386,7 +446,23 @@ class TranscriptArtifactBuilder:
             segment_count=len(document.segments),
         )
 
+    def _read_previous_manifest_hash(self, manifest_path: Path) -> str | None:
+        if not manifest_path.exists():
+            return None
+        try:
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return None
+        value = payload.get("document_hash")
+        return str(value) if isinstance(value, str) else None
+
     def _log(self, log_path: Path, event: str, **payload: object) -> None:
         entry = {"event": event, "payload": payload}
         with log_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def _document_hash(document: TranscriptDocument) -> str:
+    payload = build_transcript_payload(document)
+    raw = json.dumps(payload, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()

--- a/tests/test_asr.py
+++ b/tests/test_asr.py
@@ -60,6 +60,36 @@ class InvalidTranscriber:
         ]
 
 
+class FlakyTranscriber:
+    def __init__(self, failures_before_success: int) -> None:
+        self._failures_before_success = failures_before_success
+        self.calls = 0
+
+    def transcribe(
+        self,
+        audio_path: Path,
+        *,
+        language: str,
+        vad_filter: bool,
+        beam_size: int,
+    ) -> list[TranscriptSegment]:
+        del audio_path, language, vad_filter, beam_size
+        self.calls += 1
+        if self.calls <= self._failures_before_success:
+            raise RuntimeError("transient")
+        return [
+            TranscriptSegment(
+                segment_id=0,
+                start_sec=0.0,
+                end_sec=1.0,
+                text="ok",
+                avg_logprob=None,
+                confidence=None,
+                no_speech_prob=None,
+            )
+        ]
+
+
 def test_validate_segments_enforces_monotonic_timestamps() -> None:
     validate_segments(
         [
@@ -148,3 +178,70 @@ def test_asr_pipeline_surfaces_invalid_segments(tmp_path: Path) -> None:
 
     with pytest.raises(ASRError):
         pipeline.transcribe_run(run_dir=run_dir, language="pt")
+
+
+def test_asr_pipeline_honors_retry_count(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "retry"
+    normalized_dir = run_dir / "normalized"
+    normalized_dir.mkdir(parents=True)
+    normalized_file = normalized_dir / "0000_clip.wav"
+    normalized_file.write_bytes(b"normalized-audio")
+
+    ingestion_manifest = {
+        "files": [
+            {
+                "source_name": "clip.wav",
+                "normalized_name": "0000_clip.wav",
+                "normalized_path": str(normalized_file.resolve()),
+            }
+        ]
+    }
+    (run_dir / "ingestion_manifest.json").write_text(
+        json.dumps(ingestion_manifest), encoding="utf-8"
+    )
+
+    flaky = FlakyTranscriber(failures_before_success=1)
+    pipeline = ASRPipeline(
+        transcriber=flaky,
+        beam_size=5,
+        vad_filter=True,
+        max_retries=1,
+        retry_backoff_sec=0,
+        fail_fast=True,
+    )
+    result = pipeline.transcribe_run(run_dir=run_dir, language="pt")
+    assert result.transcribed_count == 1
+    assert flaky.calls == 2
+
+    run_dir_no_retry = tmp_path / "runs" / "retry-no"
+    normalized_dir_no_retry = run_dir_no_retry / "normalized"
+    normalized_dir_no_retry.mkdir(parents=True)
+    normalized_file_no_retry = normalized_dir_no_retry / "0000_clip.wav"
+    normalized_file_no_retry.write_bytes(b"normalized-audio")
+    (run_dir_no_retry / "ingestion_manifest.json").write_text(
+        json.dumps(
+            {
+                "files": [
+                    {
+                        "source_name": "clip.wav",
+                        "normalized_name": "0000_clip.wav",
+                        "normalized_path": str(normalized_file_no_retry.resolve()),
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    flaky_no_retry = FlakyTranscriber(failures_before_success=1)
+    no_retry_pipeline = ASRPipeline(
+        transcriber=flaky_no_retry,
+        beam_size=5,
+        vad_filter=True,
+        max_retries=0,
+        retry_backoff_sec=0,
+        fail_fast=True,
+    )
+    with pytest.raises(ASRError):
+        no_retry_pipeline.transcribe_run(run_dir=run_dir_no_retry, language="pt")
+    assert flaky_no_retry.calls == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import argparse
 import os
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+
+import rec_pipeline.cli as cli
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
@@ -24,3 +28,138 @@ def test_cli_help_smoke() -> None:
     assert completed.returncode == 0
     assert "rec" in completed.stdout
     assert "run" in completed.stdout
+
+
+def test_cli_respects_zero_asr_max_retries_override(monkeypatch: object, tmp_path: Path) -> None:
+    captured: dict[str, int] = {}
+
+    settings = SimpleNamespace(
+        default_language="pt",
+        continue_on_error=True,
+        asr_provider="local",
+        summary_provider="local",
+        asr_model_size="small",
+        asr_device="auto",
+        asr_compute_type="int8",
+        asr_beam_size=5,
+        asr_vad_filter=True,
+        asr_max_retries=3,
+        diarization_enabled=False,
+        diarization_model_name="pyannote/speaker-diarization-3.1",
+        huggingface_token=None,
+        diarization_export_speakers=True,
+        summary_local_backend="heuristic",
+        summary_model_name="unused",
+        summary_max_chunk_tokens=100,
+        summary_max_chunk_seconds=60,
+        output_language="pt",
+        external_fallback_to_local=True,
+        openai_api_key=None,
+        deepgram_api_key=None,
+        groq_api_key=None,
+        provider_timeout_sec=30,
+        provider_max_retries=2,
+        provider_retry_base_delay_sec=0.1,
+        ollama_base_url="http://localhost:11434",
+        llamacpp_server_url="http://localhost:8080",
+    )
+
+    class StubIngestionProcessor:
+        def __init__(self, *, fail_fast: bool) -> None:
+            del fail_fast
+
+        def process_directory(self, input_dir: Path, run_dir: Path) -> SimpleNamespace:
+            del input_dir
+            run_dir.mkdir(parents=True, exist_ok=True)
+            (run_dir / "ingestion_manifest.json").write_text('{"files": []}', encoding="utf-8")
+            return SimpleNamespace(files=[], normalized_count=0, skipped_count=0, errors=[])
+
+    class StubASRPipeline:
+        def __init__(
+            self,
+            *,
+            transcriber: object,
+            beam_size: int,
+            vad_filter: bool,
+            max_retries: int,
+            retry_backoff_sec: float,
+            fail_fast: bool,
+        ) -> None:
+            del transcriber, beam_size, vad_filter, retry_backoff_sec, fail_fast
+            captured["max_retries"] = max_retries
+
+        def transcribe_run(self, *, run_dir: Path, language: str) -> SimpleNamespace:
+            del language
+            asr_dir = run_dir / "asr"
+            asr_dir.mkdir(parents=True, exist_ok=True)
+            (asr_dir / "raw_transcript_segments.json").write_text(
+                '{"files": [], "errors": [], "error_count": 0}',
+                encoding="utf-8",
+            )
+            return SimpleNamespace(files=[], transcribed_count=0, skipped_count=0, errors=[])
+
+    class StubTranscriptArtifactBuilder:
+        def build(
+            self,
+            *,
+            run_dir: Path,
+            language: str,
+            prefer_diarized: bool | None = None,
+        ) -> SimpleNamespace:
+            del language, prefer_diarized
+            artifacts = run_dir / "artifacts"
+            artifacts.mkdir(parents=True, exist_ok=True)
+            (artifacts / "transcript.json").write_text(
+                '{"segments": [], "schema_version": "1.0", "language": "pt", "segment_count": 0}',
+                encoding="utf-8",
+            )
+            return SimpleNamespace(segment_count=0, generated_files=[], skipped_files=[])
+
+    class StubSummaryPipeline:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+        def build(self, *, run_dir: Path, language: str) -> SimpleNamespace:
+            del run_dir, language
+            return SimpleNamespace(generated_files=[], skipped_files=[])
+
+    monkeypatch.setattr(cli, "load_settings", lambda env_file: settings)  # type: ignore[attr-defined]
+    monkeypatch.setattr(cli, "IngestionProcessor", StubIngestionProcessor)  # type: ignore[attr-defined]
+    monkeypatch.setattr(cli, "FasterWhisperTranscriber", lambda **kwargs: object())  # type: ignore[attr-defined]
+    monkeypatch.setattr(cli, "ASRPipeline", StubASRPipeline)  # type: ignore[attr-defined]
+    monkeypatch.setattr(cli, "TranscriptArtifactBuilder", StubTranscriptArtifactBuilder)  # type: ignore[attr-defined]
+    monkeypatch.setattr(cli, "SummaryPipeline", StubSummaryPipeline)  # type: ignore[attr-defined]
+    monkeypatch.setattr(cli, "validate_provider_configuration", lambda **kwargs: None)  # type: ignore[attr-defined]
+
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+
+    args = argparse.Namespace(
+        env_file=None,
+        input=input_dir,
+        output=tmp_path / "output",
+        run_name="demo",
+        fail_fast=False,
+        lang=None,
+        asr_provider=None,
+        summary_provider=None,
+        external_fallback_to_local=None,
+        asr_model_size=None,
+        asr_device=None,
+        asr_compute_type=None,
+        asr_beam_size=None,
+        asr_vad_filter=None,
+        asr_max_retries=0,
+        summary_local_backend=None,
+        summary_model=None,
+        summary_max_chunk_tokens=None,
+        summary_max_chunk_seconds=None,
+        diarization=None,
+        diarization_model=None,
+        diarization_export_speakers=None,
+    )
+
+    code = cli._handle_run(args)
+
+    assert code == 0
+    assert captured["max_retries"] == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,3 +70,16 @@ def test_config_loading_defaults_without_external_keys(monkeypatch: object, tmp_
     assert settings.openai_api_key is None
     assert settings.deepgram_api_key is None
     assert settings.groq_api_key is None
+
+
+def test_config_default_env_file_is_loaded_from_current_working_directory(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("REC_DEFAULT_LANG", raising=False)  # type: ignore[attr-defined]
+    env_file = tmp_path / ".env"
+    env_file.write_text("REC_DEFAULT_LANG=en\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)  # type: ignore[attr-defined]
+
+    settings = load_settings()
+
+    assert settings.default_language == "en"

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -160,3 +160,4 @@ def test_diarization_failure_can_continue_with_unknown_labels(tmp_path: Path) ->
         (run_dir / "asr" / "speaker_transcript_segments.json").read_text(encoding="utf-8")
     )
     assert aggregate["files"][0]["segments"][0]["speaker"] == "UNKNOWN"
+    assert not (run_dir / "checkpoints" / "0000_clip.diarization.done").exists()

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -6,7 +6,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from rec_pipeline.evaluation import (
+    EvaluationError,
     compute_cer,
     compute_der_proxy,
     compute_summary_traceability_coverage,
@@ -37,6 +40,13 @@ def test_metric_calculations() -> None:
     assert round(cer, 3) == 0.333
     assert round(der_proxy, 3) == 0.333
     assert coverage == 1.0
+
+    # Label IDs are arbitrary; perfect swapped labels should still score as perfect diarization.
+    swapped_der_proxy = compute_der_proxy(
+        ["SPEAKER_00", "SPEAKER_00", "SPEAKER_01", "SPEAKER_01"],
+        ["SPEAKER_01", "SPEAKER_01", "SPEAKER_00", "SPEAKER_00"],
+    )
+    assert swapped_der_proxy == 0.0
 
 
 def test_evaluation_report_schema_and_artifacts(tmp_path: Path) -> None:
@@ -86,3 +96,46 @@ def test_evaluate_command_integration(tmp_path: Path) -> None:
     assert completed.returncode == 0
     assert (output_dir / "evaluation_report.json").exists()
     assert (output_dir / "evaluation_report.md").exists()
+
+
+def test_evaluate_dataset_reports_malformed_json(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "broken.json"
+    dataset_path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(EvaluationError):
+        evaluate_dataset(
+            dataset_path=dataset_path,
+            output_dir=tmp_path / "reports",
+            thresholds=default_thresholds(blocking_gates=False),
+        )
+
+
+def test_evaluate_command_handles_malformed_dataset_without_traceback(tmp_path: Path) -> None:
+    output_dir = tmp_path / "cli-broken-report"
+    dataset_path = tmp_path / "broken.json"
+    dataset_path.write_text("{", encoding="utf-8")
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
+
+    completed = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "rec_pipeline.cli",
+            "evaluate",
+            "--dataset",
+            str(dataset_path),
+            "--output",
+            str(output_dir),
+        ],  # noqa: S607
+        cwd=PROJECT_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 1
+    assert "Evaluation failed:" in completed.stdout
+    assert "Traceback" not in completed.stderr

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from rec_pipeline.ingestion import AudioProbe, IngestionProcessor, compute_offsets, sort_audio_paths
+from rec_pipeline.ingestion import (
+    AudioProbe,
+    IngestionProcessor,
+    compute_offsets,
+    scan_input_files,
+    sort_audio_paths,
+)
 
 
 def test_sort_audio_paths_is_deterministic() -> None:
@@ -78,3 +84,98 @@ def test_ingestion_resume_behavior(tmp_path: Path) -> None:
     assert (run_dir / "checkpoints" / "0000_a.normalize.done").exists()
     assert (run_dir / "checkpoints" / "0001_b.normalize.done").exists()
     assert (run_dir / "ingestion_manifest.json").exists()
+
+
+def test_scan_excludes_run_artifacts_inside_input_tree(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    run_dir = input_dir / "artifacts" / "demo"
+    source_file = input_dir / "meeting.wav"
+    run_artifact = run_dir / "normalized" / "0000_meeting.wav"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    run_artifact.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_bytes(b"source")
+    run_artifact.write_bytes(b"derived")
+
+    scanned = scan_input_files(input_dir, excluded_dirs=[run_dir])
+
+    assert scanned == [source_file]
+
+
+def test_rerun_normalization_when_checkpoint_is_missing(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    input_dir.mkdir(parents=True)
+    source_file = input_dir / "clip.wav"
+    source_file.write_bytes(b"source")
+
+    calls = {"normalize": 0}
+
+    def fake_probe(audio_path: Path) -> AudioProbe:
+        del audio_path
+        return AudioProbe(
+            duration_sec=1.0, sample_rate_hz=16000, channels=1, codec_name="pcm_s16le"
+        )
+
+    def fake_normalize(source_path: Path, destination_path: Path) -> None:
+        del source_path
+        calls["normalize"] += 1
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        destination_path.write_bytes(b"normalized")
+
+    processor = IngestionProcessor(probe_fn=fake_probe, normalize_fn=fake_normalize, fail_fast=True)
+    run_dir = tmp_path / "runs" / "demo"
+
+    first = processor.process_directory(input_dir=input_dir, run_dir=run_dir)
+    assert first.normalized_count == 1
+    assert calls["normalize"] == 1
+
+    checkpoint = run_dir / "checkpoints" / "0000_clip.normalize.done"
+    checkpoint.unlink()
+    second = processor.process_directory(input_dir=input_dir, run_dir=run_dir)
+
+    assert second.normalized_count == 1
+    assert calls["normalize"] == 2
+
+
+def test_file_index_stays_stable_when_early_file_fails_then_succeeds(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    input_dir.mkdir(parents=True)
+    early_file = input_dir / "a.wav"
+    later_file = input_dir / "b.wav"
+    early_file.write_bytes(b"a")
+    later_file.write_bytes(b"b")
+
+    durations = {early_file.resolve(): 1.0, later_file.resolve(): 2.0}
+    failed_once = {"value": False}
+    normalize_calls = {"a": 0, "b": 0}
+
+    def fake_probe(audio_path: Path) -> AudioProbe:
+        return AudioProbe(
+            duration_sec=durations[audio_path.resolve()],
+            sample_rate_hz=16000,
+            channels=1,
+            codec_name="pcm_s16le",
+        )
+
+    def fake_normalize(source_path: Path, destination_path: Path) -> None:
+        name = source_path.name
+        if name == "a.wav" and not failed_once["value"]:
+            failed_once["value"] = True
+            raise RuntimeError("transient failure")
+        normalize_calls["a" if name == "a.wav" else "b"] += 1
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        destination_path.write_bytes(b"normalized")
+
+    processor = IngestionProcessor(
+        probe_fn=fake_probe, normalize_fn=fake_normalize, fail_fast=False
+    )
+    run_dir = tmp_path / "runs" / "stable-index"
+
+    first = processor.process_directory(input_dir=input_dir, run_dir=run_dir)
+    assert first.normalized_count == 1
+    assert [item.normalized_name for item in first.files] == ["0001_b.wav"]
+
+    second = processor.process_directory(input_dir=input_dir, run_dir=run_dir)
+    assert [item.normalized_name for item in second.files] == ["0000_a.wav", "0001_b.wav"]
+    assert second.skipped_count == 1
+    assert normalize_calls["a"] == 1
+    assert normalize_calls["b"] == 1

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -135,3 +136,187 @@ def test_partial_run_recovery_preserves_existing_artifacts(tmp_path: Path) -> No
     assert "transcript.txt" in second.skipped_files
     assert "transcript.json" in second.skipped_files
     assert second.transcript_path.read_text(encoding="utf-8") == initial_txt
+
+
+def test_transcript_builder_regenerates_all_artifacts_when_segments_change(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "regen"
+    _write_manifests(run_dir)
+
+    builder = TranscriptArtifactBuilder()
+    first = builder.build(run_dir=run_dir, language="pt")
+    assert set(first.generated_files) == {"transcript.txt", "transcript.srt", "transcript.json"}
+
+    asr_payload = json.loads(
+        (run_dir / "asr" / "raw_transcript_segments.json").read_text(encoding="utf-8")
+    )
+    asr_payload["files"][0]["segments"].append(
+        {
+            "start_sec": 1.5,
+            "end_sec": 2.0,
+            "text": "novo trecho",
+            "avg_logprob": -0.1,
+            "confidence": 0.9,
+            "no_speech_prob": 0.05,
+        }
+    )
+    (run_dir / "asr" / "raw_transcript_segments.json").write_text(
+        json.dumps(asr_payload),
+        encoding="utf-8",
+    )
+
+    second = builder.build(run_dir=run_dir, language="pt")
+
+    assert set(second.generated_files) == {"transcript.txt", "transcript.srt", "transcript.json"}
+    payload = json.loads(second.json_path.read_text(encoding="utf-8"))
+    assert payload["segment_count"] == 3
+
+
+def test_timeline_allows_overlapping_segments(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "overlap"
+    (run_dir / "asr").mkdir(parents=True, exist_ok=True)
+    (run_dir / "ingestion_manifest.json").write_text(
+        json.dumps(
+            {
+                "files": [
+                    {
+                        "source_name": "a.wav",
+                        "normalized_name": "0000_a.wav",
+                        "offset_start_sec": 0.0,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "asr" / "raw_transcript_segments.json").write_text(
+        json.dumps(
+            {
+                "files": [
+                    {
+                        "source_name": "a.wav",
+                        "normalized_name": "0000_a.wav",
+                        "segments": [
+                            {"start_sec": 0.0, "end_sec": 1.0, "text": "um"},
+                            {"start_sec": 0.9, "end_sec": 2.0, "text": "dois"},
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    document = assemble_transcript(run_dir, language="pt")
+
+    assert len(document.segments) == 2
+    assert document.segments[1].absolute_start_sec == 0.9
+
+
+def test_transcript_prefers_raw_when_diarization_disabled(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "prefer-raw"
+    (run_dir / "asr").mkdir(parents=True, exist_ok=True)
+    (run_dir / "ingestion_manifest.json").write_text(
+        json.dumps(
+            {
+                "files": [
+                    {
+                        "source_name": "a.wav",
+                        "normalized_name": "0000_a.wav",
+                        "offset_start_sec": 0.0,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    raw_payload = {
+        "files": [
+            {
+                "source_name": "a.wav",
+                "normalized_name": "0000_a.wav",
+                "segments": [{"start_sec": 0.0, "end_sec": 1.0, "text": "raw"}],
+            }
+        ]
+    }
+    diarized_payload = {
+        "files": [
+            {
+                "source_name": "a.wav",
+                "normalized_name": "0000_a.wav",
+                "segments": [
+                    {"start_sec": 0.0, "end_sec": 1.0, "text": "diarized", "speaker": "S0"}
+                ],
+            }
+        ]
+    }
+    (run_dir / "asr" / "raw_transcript_segments.json").write_text(
+        json.dumps(raw_payload),
+        encoding="utf-8",
+    )
+    (run_dir / "asr" / "speaker_transcript_segments.json").write_text(
+        json.dumps(diarized_payload),
+        encoding="utf-8",
+    )
+    (run_dir / "run_metadata.json").write_text(
+        json.dumps({"diarization_enabled": False}),
+        encoding="utf-8",
+    )
+
+    document = assemble_transcript(run_dir, language="pt", prefer_diarized=False)
+
+    assert document.segments[0].text == "raw"
+
+
+def test_transcript_uses_raw_when_diarized_payload_is_stale(tmp_path: Path) -> None:
+    run_dir = tmp_path / "runs" / "stale-diarized"
+    (run_dir / "asr").mkdir(parents=True, exist_ok=True)
+    (run_dir / "ingestion_manifest.json").write_text(
+        json.dumps(
+            {
+                "files": [
+                    {
+                        "source_name": "a.wav",
+                        "normalized_name": "0000_a.wav",
+                        "offset_start_sec": 0.0,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    raw_path = run_dir / "asr" / "raw_transcript_segments.json"
+    diarized_path = run_dir / "asr" / "speaker_transcript_segments.json"
+    raw_path.write_text(
+        json.dumps(
+            {
+                "files": [
+                    {
+                        "source_name": "a.wav",
+                        "normalized_name": "0000_a.wav",
+                        "segments": [{"start_sec": 0.0, "end_sec": 1.0, "text": "fresh raw"}],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    diarized_path.write_text(
+        json.dumps(
+            {
+                "files": [
+                    {
+                        "source_name": "a.wav",
+                        "normalized_name": "0000_a.wav",
+                        "segments": [{"start_sec": 0.0, "end_sec": 1.0, "text": "stale diarized"}],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    old_time = raw_path.stat().st_mtime - 10
+    os.utime(diarized_path, (old_time, old_time))
+
+    document = assemble_transcript(run_dir, language="pt", prefer_diarized=True)
+
+    assert document.segments[0].text == "fresh raw"


### PR DESCRIPTION
## Summary
This follow-up PR addresses reviewer feedback raised across stacked PRs #11 through #19.

### Fixed from #11
- config loading now resolves default `.env` from the current working directory (`Path.cwd() / ".env"`)

### Fixed from #12
- input scanning excludes run artifact trees when output lives under input
- normalization now re-runs when checkpoint/metadata are missing (even if a `.wav` exists)
- stable indexing now derives from deterministic scan order, not success count

### Fixed from #13
- ASR retry semantics now honor “max retries” as retries-after-first-attempt
- CLI now preserves explicit `--asr-max-retries 0`

### Fixed from #14
- transcript artifacts now regenerate when assembled segment content changes (hash-based)
- transcript timeline validation now accepts overlapping segments while preserving monotonic start/end constraints

### Fixed from #15
- empty-transcript summarization now emits non-empty required sections
- summary checkpoint skip now happens before model inference, with transcript-hash freshness checks

### Fixed from #16
- transcript assembly now prefers diarized payload only when explicitly requested/fresh
- diarization fallback (`UNKNOWN`) no longer writes success checkpoints after failures

### Fixed from #17
- external ASR now sends audio content (base64 payload) instead of local filesystem path
- external summary payload now uses chat `messages` structure for chat-completions providers

### Fixed from #18
- DER proxy computation is now speaker-label invariant via optimal label mapping
- malformed evaluation dataset JSON is wrapped as `EvaluationError` for clean CLI failure handling

### Fixed from #19
- release workflow dispatch now requires explicit `tag_name` and uses it for published releases

### Additional
- added project-level `AGENTS.md` with practical learnings/best practices
- added regression tests for all addressed findings

## Validation
- `make lint`
- `make format-check`
- `make typecheck`
- `make test`
- `python -m rec_pipeline.cli evaluate --dataset tests/fixtures/eval_dataset.json --output /tmp/rec-eval-fix-smoke`
- workflow YAML parse validation (`.github/workflows/*.yml`)
