### PR TITLE
[ci] Fix markdown-lint violations introduced/surfaced after #25

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Summary
+# Summary
 
 Describe the scoped change and why it is needed.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ rec run \
 ```
 
 Run artifacts are created under `artifacts/<run-name>/` and include:
+
 - `asr/raw/*.segments.json`
 - `asr/raw_transcript_segments.json`
 - `artifacts/transcript.txt`
@@ -115,10 +116,12 @@ rec evaluate \
 ```
 
 Evaluation artifacts:
+
 - `evaluation_report.json`
 - `evaluation_report.md`
 
 Committed baseline reference report:
+
 - `evaluation/reports/baseline/evaluation_report.json`
 
 ## CI/CD

--- a/docs/engineering/merge-philosophy.md
+++ b/docs/engineering/merge-philosophy.md
@@ -5,8 +5,8 @@
 `rec` follows a throughput-first merge philosophy: waiting is expensive, and
 corrections are cheap when pull requests stay small.
 
-This is inspired by OpenAI's Harness Engineering write-up (February 11, 2026):
-https://openai.com/index/harness-engineering/
+This is inspired by OpenAI's
+[Harness Engineering write-up (February 11, 2026)](https://openai.com/index/harness-engineering/).
 
 The important tradeoff is context-dependent:
 

--- a/evaluation/reports/baseline/evaluation_report.md
+++ b/evaluation/reports/baseline/evaluation_report.md
@@ -6,15 +6,18 @@
 - Gate status: **passed**
 
 ## Aggregate Metrics
+
 - WER: 0.196
 - CER: 0.065
 - DER proxy: 0.125
 - Summary traceability coverage: 1.000
 
 ## Quality Gates
+
 - No threshold violations
 
 ## Scenario Metrics
+
 - `pt_short_sync`
   - multi_file: False
   - wer: 0.154


### PR DESCRIPTION
## Summary
- fix markdownlint violations reported in issue #26
- convert PR template first heading to H1 (MD041)
- replace bare URL with markdown link (MD034)
- add required blank lines around headings/lists in baseline report and README (MD022/MD032)

## Validation
- npx --yes markdownlint-cli2 '**/*.md' '#node_modules'

Fixes #26